### PR TITLE
Add a version to the script and correct the target triple

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@
 # the LICENSE file found in the root directory of this source tree.
 
 # Heavily influenced by https://github.com/theopolis/build-anywhere
+# Version 1.0.0
 
 function build_gcc() {
   # Clone and build CrosstoolNG.

--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 #!/bin/bash
 # For GCC configurations please look at crosstool-ng-config
 
-TUPLE=x86_64-anywhere-linux-gnu
+TUPLE=x86_64-osquery-linux-gnu
 
 ZLIB_VER="1.2.11"
 ZLIB_URL="https://zlib.net/zlib-${ZLIB_VER}.tar.gz"


### PR DESCRIPTION
The version should be used when preparing an archive of the toolchain.
Also changed the target triple middle part from "anywhere" to "osquery".