### PR TITLE
Add CHANGELOG and version 1.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+
+<a name="1.0.0"></a>
+## [1.0.0](https://github.com/osquery/osquery-toolchain/releases/tag/1.0.0)
+
+This is the first version of the `x86_64-osquery-linux-gnu` toolchain.
+It is designed to build a release version of osquery such that the resulting binaries can be run on a large number of Linux flavors.
+
+A LLVM compiler, minimal sysroot, and other required tools such as GCC's assembler are provided.
+
+Versions used:
+- linux headers 4.7.10
+- zlib 1.2.11
+- llvm 8.0.1
+- gcc 8.3.0
+- glibc 2.12.2
+- binutils 2.30
+- crosstool-ng 1.24.0
+
+The following assets and hashes are included in this release.
+
+```
+cfa65cfcc40cd804d276a43a2c3a0031bd371b32d35404e53e5450170ac63a69  osquery-toolchain-1.0.0.tar.xz
+```


### PR DESCRIPTION
The hashes section of the release notes provides integrity that we will not change (out from under someone's nose) the provided tarball.