### PR TITLE
Update LLVM toolchain to 9.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The rough steps used to achieve the above goals:
 The version of crosstool-ng used is 1.24.0
 The version of the GCC compiler built by crosstool-ng is 8.3.0
 The version of the libc library built by crosstool-ng is 2.12.2
-The version of LLVM/Clang built by the script is 8.0.1
+The version of LLVM/Clang built by the script is 9.0.1
 The version of the zlib library built by the script is 1.2.11
 
 Among other, the toolchain LLVM/Clang includes the clang static analyzer, scan-build, clang-format, clang-tidy.

--- a/config
+++ b/config
@@ -8,7 +8,7 @@ ZLIB_VER="1.2.11"
 ZLIB_URL="https://zlib.net/zlib-${ZLIB_VER}.tar.gz"
 ZLIB_SHA="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 
-LLVM_VERSION="8.0.1"
+LLVM_VERSION="9.0.1"
 GCC_VERSION="8.3.0" # Notice: this has to match the same version that has been configured in crosstool-ng-config
 
 PARALLEL_JOBS=$(( $(nproc)+1 ))


### PR DESCRIPTION
Beyond using the latest and greatest stable release,
there are some fixes needed in the scan-build scripts
to be able to work with CMake and its sysroot option.