### PR TITLE
Fix scan-build support for sysroot=

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For the instructions we will use Ubuntu 18.04.
 
 ## Prerequisites
 ```
-sudo apt install --no-install-recommends g++-8 gcc-8 automake autoconf gettext bison flex unzip help2man libtool-bin libncurses-dev make ninja-build
+sudo apt install --no-install-recommends g++-8 gcc-8 automake autoconf gettext bison flex unzip help2man libtool-bin libncurses-dev make ninja-build patch
 ```
 Then use `update-alternatives` to tell the system that the version of GCC/G++ and CPP is the default we would like to use:
 ```

--- a/build.sh
+++ b/build.sh
@@ -296,6 +296,11 @@ if [[ ! -d ${LLVM_SRC} ]]; then
   mkdir -p `dirname $LLVM_SRC`
   cd `dirname $LLVM_SRC`
   git clone https://github.com/llvm/llvm-project.git llvm -b llvmorg-$LLVM_VERSION --single-branch --depth 1
+
+  ## Patch the scan-build script so it works with sysroot= in the link options
+  cd llvm
+  patch -p1 < $SCRIPT_DIR/patches/00_scan-build-link-options.patch
+  patch -p1 < $SCRIPT_DIR/patches/01_scan-build-perl-warning.patch
 fi
 
 LLVM_DISABLED_TOOLS="-DLLVM_TOOL_BUGPOINT_BUILD=OFF"

--- a/patches/00_scan-build-link-options.patch
+++ b/patches/00_scan-build-link-options.patch
@@ -1,0 +1,49 @@
+From 473d0d7f569c84446d9880727403524d4a9838eb Mon Sep 17 00:00:00 2001
+From: Artem Dergachev <artem.dergachev@gmail.com>
+Date: Thu, 5 Sep 2019 00:44:56 +0000
+Subject: [PATCH] [analyzer] scan-build: handle --sysroot=/path in addition to
+ --sysroot /path.
+
+Current code assumes flags in CompilerLinkerOptionMap don't use =,
+which isn't always true.
+
+Patch by Chris Laplante!
+
+Differential Revision: https://reviews.llvm.org/D66569
+
+llvm-svn: 371002
+---
+ clang/tools/scan-build/libexec/ccc-analyzer | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/clang/tools/scan-build/libexec/ccc-analyzer b/clang/tools/scan-build/libexec/ccc-analyzer
+index e1635e6c29b8..6d24a1af4539 100755
+--- a/clang/tools/scan-build/libexec/ccc-analyzer
++++ b/clang/tools/scan-build/libexec/ccc-analyzer
+@@ -498,7 +498,8 @@ my $HasSDK = 0;
+ # Process the arguments.
+ foreach (my $i = 0; $i < scalar(@ARGV); ++$i) {
+   my $Arg = $ARGV[$i];
+-  my ($ArgKey) = split /=/,$Arg,2;
++  my @ArgParts = split /=/,$Arg,2;
++  my $ArgKey = @ArgParts[0];
+ 
+   # Be friendly to "" in the argument list.
+   if (!defined($ArgKey)) {
+@@ -566,10 +567,12 @@ foreach (my $i = 0; $i < scalar(@ARGV); ++$i) {
+     push @CompileOpts,$Arg;
+     push @LinkOpts,$Arg;
+ 
+-    while ($Cnt > 0) {
+-      ++$i; --$Cnt;
+-      push @CompileOpts, $ARGV[$i];
+-      push @LinkOpts, $ARGV[$i];
++    if (scalar @ArgParts == 1) {
++      while ($Cnt > 0) {
++        ++$i; --$Cnt;
++        push @CompileOpts, $ARGV[$i];
++        push @LinkOpts, $ARGV[$i];
++      }
+     }
+     next;
+   }

--- a/patches/01_scan-build-perl-warning.patch
+++ b/patches/01_scan-build-perl-warning.patch
@@ -1,0 +1,25 @@
+From ea27b932b58cb6cf9d2f1ad1eddd187ee34b9a90 Mon Sep 17 00:00:00 2001
+From: Sylvestre Ledru <sylvestre@debian.org>
+Date: Fri, 13 Sep 2019 09:31:19 +0000
+Subject: [PATCH] Fix a perl warning: Scalar value @ArgParts[0] better written
+ as $ArgParts[0] at /usr/share/clang/scan-build-10/libexec/ccc-analyzer line
+ 502.
+
+llvm-svn: 371832
+---
+ clang/tools/scan-build/libexec/ccc-analyzer | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/clang/tools/scan-build/libexec/ccc-analyzer b/clang/tools/scan-build/libexec/ccc-analyzer
+index 6d24a1af4539..800f38b5ba24 100755
+--- a/clang/tools/scan-build/libexec/ccc-analyzer
++++ b/clang/tools/scan-build/libexec/ccc-analyzer
+@@ -499,7 +499,7 @@ my $HasSDK = 0;
+ foreach (my $i = 0; $i < scalar(@ARGV); ++$i) {
+   my $Arg = $ARGV[$i];
+   my @ArgParts = split /=/,$Arg,2;
+-  my $ArgKey = @ArgParts[0];
++  my $ArgKey = $ArgParts[0];
+ 
+   # Be friendly to "" in the argument list.
+   if (!defined($ArgKey)) {


### PR DESCRIPTION
The `ccc-analyzer` script which is a wrapper for the compilation when using scan-build, do not support the sysroot parameter given with `--sysroot=`, as we use in osquery since it's what CMake uses.
A fix has been done upstream but it's only available in LLVM/Clang 10 which is not stable, so we backport and apply those two fixes to our version.