### PR TITLE
Rough in docker for the builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:18.04 AS base1
+
+# cmake version. See https://github.com/osquery/osquery/pull/6801 We
+# might have to fall back to something earlier and build cmake :\
+ENV cmakeVer 3.19.6
+
+RUN apt update -q -y
+RUN apt upgrade -q -y
+RUN apt install -q -y --no-install-recommends \
+	git \
+	make \
+	cppcheck \
+	ccache \
+	python \
+	python3 \
+	sudo \
+	wget \
+	ca-certificates \
+	tar \
+	icu-devtools \
+	flex \
+	bison \
+	xz-utils \
+	python3-setuptools \
+	python3-psutil \
+	python3-pip \
+	python3-six \
+	rpm \
+	dpkg-dev \
+	file \
+	elfutils \
+	locales \
+	python3-wheel
+RUN apt clean && rm -rf /var/lib/apt/lists/* \
+RUN pip3 install timeout_decorator thrift==0.11.0 osquery pexpect==3.3 docker
+
+FROM base1 AS base2
+RUN case $(uname -m) in aarch64) ARCH="aarch64" ;; amd64|x86_64) ARCH="x86_64" ;; esac \
+	&& wget https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-${ARCH}.tar.xz \
+	&& sudo tar xvf osquery-toolchain-1.1.0-${ARCH}.tar.xz -C /usr/local \
+	&& rm osquery-toolchain-1.1.0-${ARCH}.tar.xz \
+	&& wget https://github.com/Kitware/CMake/releases/download/v${cmakeVer}/cmake-${cmakeVer}-Linux-${ARCH}.tar.gz \
+	&& sudo tar xvf cmake-${cmakeVer}-Linux-${ARCH}.tar.gz -C /usr/local --strip 1 \
+	&& rm cmake-${cmakeVer}-Linux-${ARCH}.tar.gz
+
+RUN rm -rf /usr/local/doc /usr/local/bin/cmake-gui
+
+FROM base2 AS base3
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# Squash all layers down using a giant COPY. It's kinda gross, but it
+# works. Though the layers are only adding about 50 megs on a 1gb
+# image.
+FROM scratch AS builder
+COPY --from=base3 / /

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:
 # registry to actually use it. Else it goes no where. Testing in my
 # personal space
 containers:
-	docker buildx build --platform linux/amd64,linux/arm64 --push -t directionless/osqbuildbeta .
+	docker buildx build --platform linux/amd64,linux/arm64 --push -t osquery/builder .
 
 arm:
 	docker buildx build --platform linux/arm64 --load -t directionless/osqbuildbeta:$@ .

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ containers:
 	docker buildx build --platform linux/amd64,linux/arm64 --push -t osquery/builder .
 
 arm:
-	docker buildx build --platform linux/arm64 --load -t directionless/osqbuildbeta:$@ .
+	docker buildx build --platform linux/arm64 --load -t osquerybuild:$@ .
 x86:
-	docker buildx build --platform linux/amd64 --load -t directionless/osqbuildbeta:$@ .
+	docker buildx build --platform linux/amd64 --load -t osquerybuild:$@ .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+all:
+
+# the --load pushes the build into the local docker cache. But that's
+# broken for local docker. So we need to --push to get it to a
+# registry to actually use it. Else it goes no where. Testing in my
+# personal space
+containers:
+	docker buildx build --platform linux/amd64,linux/arm64 --push -t directionless/osqbuildbeta .
+
+arm:
+	docker buildx build --platform linux/arm64 --load -t directionless/osqbuildbeta:$@ .
+x86:
+	docker buildx build --platform linux/amd64 --load -t directionless/osqbuildbeta:$@ .


### PR DESCRIPTION
This is an update to
https://github.com/osquery/osquery/blob/4dd97ea6a09cd14483f2fe28488fa94d38939dc1/tools/ci/osquery-ubuntu18.04-toolchain.dockerfile
to be cross platform. It builds in buildx.

I suspect this is a better repo for it.

Pending a better resolution for the cmake version issue, I'm building it from source. However, building cmake for aarch, inside a dockerx emulator takes ~2 hours. So it's probably not a good fit for github actions. So manual it is...